### PR TITLE
Convert to single scrolling portfolio

### DIFF
--- a/client/src/App.jsx
+++ b/client/src/App.jsx
@@ -1,19 +1,17 @@
-import { Routes, Route } from 'react-router-dom';
 import Home from './pages/Home.jsx';
 import Projects from './pages/Projects';
 import About from './pages/About';
 import Contact from './pages/Contact';
 import Navbar from './components/navbar/Navbar.jsx';
+
 function App() {
   return (
     <>
       <Navbar />
-      <Routes>
-        <Route path="/" element={<Home />} />
-        <Route path="/projects" element={<Projects />} />
-        <Route path="/about" element={<About />} />
-        <Route path="/contact" element={<Contact />} />
-      </Routes>
+      <Home />
+      <Projects />
+      <About />
+      <Contact />
     </>
   );
 }

--- a/client/src/components/navbar/Navbar.jsx
+++ b/client/src/components/navbar/Navbar.jsx
@@ -1,5 +1,4 @@
 import { useState } from 'react';
-import { Link } from 'react-router-dom';
 import './Navbar.css';
 
 function Navbar() {
@@ -10,10 +9,10 @@ function Navbar() {
       <div className="logo">AllanDev</div>
 
       <div className={`nav-links ${menuOpen ? 'open' : ''}`}>
-        <Link to="/" onClick={() => setMenuOpen(false)}>Home</Link>
-        <Link to="/projects" onClick={() => setMenuOpen(false)}>Projects</Link>
-        <Link to="/about" onClick={() => setMenuOpen(false)}>About</Link>
-        <Link to="/contact" onClick={() => setMenuOpen(false)}>Contact</Link>
+        <a href="#home" onClick={() => setMenuOpen(false)}>Home</a>
+        <a href="#projects" onClick={() => setMenuOpen(false)}>Projects</a>
+        <a href="#about" onClick={() => setMenuOpen(false)}>About</a>
+        <a href="#contact" onClick={() => setMenuOpen(false)}>Contact</a>
       </div>
 
       <div className="hamburger" onClick={() => setMenuOpen(!menuOpen)}>

--- a/client/src/main.jsx
+++ b/client/src/main.jsx
@@ -1,12 +1,9 @@
 import React from 'react';
 import ReactDOM from 'react-dom/client';
-import { BrowserRouter } from 'react-router-dom';
 import App from './App';
 import './styles.css';
 // import './index.css';
 
 ReactDOM.createRoot(document.getElementById('root')).render(
-  <BrowserRouter>
-    <App />
-  </BrowserRouter>
+  <App />
 );

--- a/client/src/pages/About.css
+++ b/client/src/pages/About.css
@@ -1,0 +1,18 @@
+.about-section {
+  display: flex;
+  align-items: center;
+  gap: 2rem;
+  padding: 4rem 2rem;
+  background: var(--charcoal);
+  min-height: 100vh;
+}
+
+.about-section img {
+  max-width: 400px;
+  border-radius: 8px;
+}
+
+.about-text h2 {
+  color: var(--gold);
+  margin-bottom: 1rem;
+}

--- a/client/src/pages/About.jsx
+++ b/client/src/pages/About.jsx
@@ -1,4 +1,33 @@
+import { useEffect, useRef } from 'react';
+import './About.css';
+
 function About() {
-    return <h1>Things about me</h1>;
-  }
-  export default About;
+  const sectionRef = useRef(null);
+
+  useEffect(() => {
+    const observer = new IntersectionObserver(
+      ([entry]) => {
+        entry.target.classList.toggle('slide-in', entry.isIntersecting);
+      },
+      { threshold: 0.2 }
+    );
+    if (sectionRef.current) observer.observe(sectionRef.current);
+    return () => observer.disconnect();
+  }, []);
+
+  return (
+    <section id="about" ref={sectionRef} className="about-section slide-left">
+      <img src="https://via.placeholder.com/400x300" alt="About" />
+      <div className="about-text">
+        <h2>About Me</h2>
+        <p>
+          I'm a passionate developer who loves building modern web applications.
+          This space will highlight my journey, skills and what I enjoy most
+          about coding.
+        </p>
+      </div>
+    </section>
+  );
+}
+
+export default About;

--- a/client/src/pages/Contact.css
+++ b/client/src/pages/Contact.css
@@ -1,0 +1,24 @@
+.contact-section {
+  padding: 4rem 2rem;
+  min-height: 100vh;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  background: var(--black);
+}
+
+.contact-form {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+  width: 100%;
+  max-width: 400px;
+}
+
+.contact-form input,
+.contact-form textarea {
+  padding: 0.75rem;
+  border-radius: 5px;
+  border: none;
+}

--- a/client/src/pages/Contact.jsx
+++ b/client/src/pages/Contact.jsx
@@ -1,4 +1,31 @@
+import { useEffect, useRef } from 'react';
+import './Contact.css';
+
 function Contact() {
-    return <h1>Contact me</h1>;
-  }
-  export default Contact;
+  const sectionRef = useRef(null);
+
+  useEffect(() => {
+    const observer = new IntersectionObserver(
+      ([entry]) => {
+        entry.target.classList.toggle('slide-in', entry.isIntersecting);
+      },
+      { threshold: 0.2 }
+    );
+    if (sectionRef.current) observer.observe(sectionRef.current);
+    return () => observer.disconnect();
+  }, []);
+
+  return (
+    <section id="contact" ref={sectionRef} className="contact-section slide-right">
+      <h2>Contact Me</h2>
+      <form className="contact-form">
+        <input type="text" placeholder="Name" />
+        <input type="email" placeholder="Email" />
+        <textarea placeholder="Message" rows="5" />
+        <button className="cta" type="submit">Send</button>
+      </form>
+    </section>
+  );
+}
+
+export default Contact;

--- a/client/src/pages/Home.jsx
+++ b/client/src/pages/Home.jsx
@@ -1,18 +1,31 @@
 import './Home.css';
-import { Link } from 'react-router-dom';
+import { useEffect, useRef } from 'react';
 
 function Home() {
+  const sectionRef = useRef(null);
+
+  useEffect(() => {
+    const observer = new IntersectionObserver(
+      ([entry]) => {
+        entry.target.classList.toggle('slide-in', entry.isIntersecting);
+      },
+      { threshold: 0.2 }
+    );
+    if (sectionRef.current) observer.observe(sectionRef.current);
+    return () => observer.disconnect();
+  }, []);
+
   return (
-    <section className="hero">
+    <section id="home" ref={sectionRef} className="hero slide-left">
       <div className="hero-content">
         <h1>Hi, I'm Allan</h1>
         <p className="tagline">Full stack developer crafting modern, performant web applications.</p>
         <p className="subtitle">I blend design sensibility with clean code to deliver polished digital experiences.</p>
         <div className="cta-group">
-          <a href="/projects">
+          <a href="#projects">
             <button className="cta">View Projects</button>
           </a>
-          <a href="/contact">
+          <a href="#contact">
             <button className="cta secondary">Get in Touch</button>
           </a>
         </div>

--- a/client/src/pages/Projects.jsx
+++ b/client/src/pages/Projects.jsx
@@ -18,9 +18,18 @@ const projects = [
 ];
 
 function Projects() {
+  const sectionRef = useRef(null);
   const cardsRef = useRef([]);
 
   useEffect(() => {
+    const sectionObserver = new IntersectionObserver(
+      ([entry]) => {
+        entry.target.classList.toggle('slide-in', entry.isIntersecting);
+      },
+      { threshold: 0.2 }
+    );
+    if (sectionRef.current) sectionObserver.observe(sectionRef.current);
+
     const observer = new IntersectionObserver(
       (entries) => {
         entries.forEach((entry) => {
@@ -35,6 +44,7 @@ function Projects() {
     });
 
     return () => {
+      if (sectionRef.current) sectionObserver.unobserve(sectionRef.current);
       cardsRef.current.forEach((card) => {
         if (card) observer.unobserve(card);
       });
@@ -42,7 +52,11 @@ function Projects() {
   }, []);
 
   return (
-    <div className="projects-page">
+    <section
+      id="projects"
+      ref={sectionRef}
+      className="projects-page slide-right"
+    >
       <h2>My Projects</h2>
       <div className="project-grid">
         {projects.map((project, index) => (
@@ -62,7 +76,7 @@ function Projects() {
           </div>
         ))}
       </div>
-    </div>
+    </section>
   );
 }
 

--- a/client/src/styles.css
+++ b/client/src/styles.css
@@ -59,3 +59,22 @@ p {
 .navbar a {
   font-weight: 500;
 }
+
+.slide-left,
+.slide-right {
+  opacity: 0;
+  transition: transform 0.6s ease, opacity 0.6s ease;
+}
+
+.slide-left {
+  transform: translateX(-100px);
+}
+
+.slide-right {
+  transform: translateX(100px);
+}
+
+.slide-in {
+  opacity: 1;
+  transform: translateX(0);
+}


### PR DESCRIPTION
## Summary
- switch to a single page layout instead of React Router
- update navigation to anchor links
- implement slide-in sections for Home, Projects, About, and Contact
- add placeholder content with stock images for About and Contact
- include global slide-left/right CSS animations

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_683f848163f48331a72514170bede8ec