### PR TITLE
Fix project card slide animation

### DIFF
--- a/client/src/pages/Projects.jsx
+++ b/client/src/pages/Projects.jsx
@@ -18,18 +18,9 @@ const projects = [
 ];
 
 function Projects() {
-  const sectionRef = useRef(null);
   const cardsRef = useRef([]);
 
   useEffect(() => {
-    const sectionObserver = new IntersectionObserver(
-      ([entry]) => {
-        entry.target.classList.toggle('slide-in', entry.isIntersecting);
-      },
-      { threshold: 0.2 }
-    );
-    if (sectionRef.current) sectionObserver.observe(sectionRef.current);
-
     const observer = new IntersectionObserver(
       (entries) => {
         entries.forEach((entry) => {
@@ -44,7 +35,6 @@ function Projects() {
     });
 
     return () => {
-      if (sectionRef.current) sectionObserver.unobserve(sectionRef.current);
       cardsRef.current.forEach((card) => {
         if (card) observer.unobserve(card);
       });
@@ -52,11 +42,7 @@ function Projects() {
   }, []);
 
   return (
-    <section
-      id="projects"
-      ref={sectionRef}
-      className="projects-page slide-right"
-    >
+    <section id="projects" className="projects-page">
       <h2>My Projects</h2>
       <div className="project-grid">
         {projects.map((project, index) => (


### PR DESCRIPTION
## Summary
- remove project section intersection logic
- observe only project cards for slide in effect

## Testing
- `npm --prefix client run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_6843e464adac8331a044f95ffbf3e6cc