### PR TITLE
Refocus portfolio toward web development

### DIFF
--- a/client/src/App.jsx
+++ b/client/src/App.jsx
@@ -4,6 +4,8 @@ import Home from './pages/Home';
 import About from './pages/About';
 import SuccessStories from './pages/SuccessStories';
 import BookSession from './pages/BookSession';
+import Services from './pages/Services';
+import Pricing from './pages/Pricing';
 
 function App() {
   return (
@@ -14,6 +16,8 @@ function App() {
         <Route path="/about" element={<About />} />
         <Route path="/stories" element={<SuccessStories />} />
         <Route path="/book" element={<BookSession />} />
+        <Route path="/services" element={<Services />} />
+        <Route path="/pricing" element={<Pricing />} />
       </Routes>
     </Router>
   );

--- a/client/src/pages/About.jsx
+++ b/client/src/pages/About.jsx
@@ -4,9 +4,9 @@ import "../styles/about.css";
 export default function About() {
   return (
     <div className="about-container">
-      <h1 className="about-title">About Us</h1>
+      <h1 className="about-title">About</h1>
 
-      {/* Mom Section */}
+      {/* Allan Section */}
       <Motion.div
         className="about-section"
         initial={{ opacity: 0, x: 100 }}
@@ -14,17 +14,15 @@ export default function About() {
         transition={{ duration: 0.8 }}
         viewport={{ once: true, amount: 0.5 }}
       >
-        <img src="/images/marie.jpg" alt="Mom" className="about-image mom-image" />
+        <img src="/images/allan-home.jpg" alt="Allan" className="about-image" />
         <div className="about-text">
-          <h2>Marie Street</h2>
-          <p>
-            I’m a certified personal trainer with a passion for movement and healthy
-            living. I help others realize their strength no matter their age!
-          </p>
+          <h2>Allan Elias</h2>
+          <p>Lead Developer, UX-minded Frontend.</p>
+          <p>Building performant, accessible web apps with modern tools.</p>
         </div>
       </Motion.div>
 
-      {/* Allan Section */}
+      {/* Advisor Section */}
       <Motion.div
         className="about-section reverse"
         initial={{ opacity: 0, x: -100 }}
@@ -32,14 +30,12 @@ export default function About() {
         transition={{ duration: 0.8 }}
         viewport={{ once: true, amount: 0.5 }}
       >
+        <img src="/images/marie-home.jpg" alt="Marie" className="about-image mom-image" />
         <div className="about-text">
-          <h2>Allan Elias</h2>
-          <p>
-            I’m a fitness enthusiast dedicated to helping people feel
-            strong, confident, and supported in every step of their journey.
-          </p>
+          <h2>Marie Street</h2>
+          <p>Partner & Advisor</p>
+          <p>Supporting strategy and client success throughout projects.</p>
         </div>
-        <img src="/images/allan-deadlift.jpg" alt="Allan" className="about-image" />
       </Motion.div>
     </div>
   );

--- a/client/src/pages/Home.jsx
+++ b/client/src/pages/Home.jsx
@@ -26,23 +26,32 @@ export default function Home() {
         <div className="hero-image-bg"></div>
       </Motion.section>
 
-      {/* Trust Section */}
+      {/* Feature Pills */}
       <Motion.section
-        className="trust"
+        className="features"
         initial={{ opacity: 0, x: 50 }}
         whileInView={{ opacity: 1, x: 0 }}
         transition={{ duration: 0.8 }}
         viewport={{ once: false, amount: 0.5 }}
       >
-        <div className="trust-item">
-          <h3>💪 Family-Owned & Operated</h3>
-        </div>
-        <div className="trust-item">
-          <h3>🧠 Certified & Personalized Plans</h3>
-        </div>
-        <div className="trust-item">
-          <h3>🧓 Age-Inclusive Training</h3>
-        </div>
+        <a href="/services" className="feature-item">
+          <h3>⚡ Blazing-fast Sites</h3>
+        </a>
+        <a href="/services" className="feature-item">
+          <h3>📱 Responsive by Default</h3>
+        </a>
+        <a href="/services" className="feature-item">
+          <h3>🔍 SEO Foundations</h3>
+        </a>
+        <a href="/services" className="feature-item">
+          <h3>🛠️ Modern Stack (MERN)</h3>
+        </a>
+        <a href="/services" className="feature-item">
+          <h3>🔒 Secure & Accessible</h3>
+        </a>
+        <a href="/services" className="feature-item">
+          <h3>🚀 Deployed on Vercel</h3>
+        </a>
       </Motion.section>
 
       {/* Bio Preview */}
@@ -56,12 +65,18 @@ export default function Home() {
         <div className="bio-card">
           <img src="/images/allan-home.jpg" alt="Allan" />
           <h4>Allan Elias</h4>
-          <p>Certified Personal Trainer. Transformation Coach.</p>
+          <p className="bio-role">Lead Developer, UX-minded Frontend</p>
+          <p className="bio-desc">
+            Crafting fast, accessible interfaces for modern web apps.
+          </p>
         </div>
         <div className="bio-card">
-          <img src="/images/marie-home.jpg" alt="Mom" />
+          <img src="/images/marie-home.jpg" alt="Marie" />
           <h4>Marie Street</h4>
-          <p>Strength & Wellness Mentor. Age-Friendly Fitness Expert.</p>
+          <p className="bio-role">Partner & Advisor</p>
+          <p className="bio-desc">
+            Strategic insight and client empathy in every collaboration.
+          </p>
         </div>
         <a href="/about" className="bio-link">Read More →</a>
       </Motion.section>
@@ -91,7 +106,17 @@ export default function Home() {
         viewport={{ once: false, amount: 0.5 }}
       >
         <h2>Ready to build?</h2>
-        <a href="/book"><button>Schedule a Consultation</button></a>
+        <div className="footer-buttons">
+          <a href="/book">
+            <button>Schedule a Consultation</button>
+          </a>
+          <a href="/pricing">
+            <button className="ghost">See Pricing</button>
+          </a>
+        </div>
+        <p className="trust-line">
+          Average 1–2 week delivery • Free homepage mockup
+        </p>
       </Motion.section>
     </div>
   );

--- a/client/src/pages/Pricing.jsx
+++ b/client/src/pages/Pricing.jsx
@@ -1,0 +1,10 @@
+import "../styles/about.css";
+
+export default function Pricing() {
+  return (
+    <div className="about-container" style={{ textAlign: "center" }}>
+      <h1 className="about-title">Pricing</h1>
+      <p>Pricing details will be published soon.</p>
+    </div>
+  );
+}

--- a/client/src/pages/Services.jsx
+++ b/client/src/pages/Services.jsx
@@ -1,0 +1,10 @@
+import "../styles/about.css";
+
+export default function Services() {
+  return (
+    <div className="about-container" style={{ textAlign: "center" }}>
+      <h1 className="about-title">Services</h1>
+      <p>Details about development services coming soon.</p>
+    </div>
+  );
+}

--- a/client/src/styles/home.css
+++ b/client/src/styles/home.css
@@ -82,16 +82,16 @@
   }
   
   
-  /* Trust Section */
-  .trust {
+  /* Features */
+  .features {
     display: flex;
     justify-content: space-between;
     margin: 60px 0;
     gap: 20px;
     flex-wrap: wrap;
   }
-  
-  .trust-item {
+
+  .feature-item {
     flex: 1;
     min-width: 200px;
     text-align: center;
@@ -99,6 +99,8 @@
     background: #f7f7f7;
     border-radius: 8px;
     font-weight: bold;
+    color: inherit;
+    text-decoration: none;
   }
   
   /* Bio Preview */
@@ -109,16 +111,24 @@
   
   .bio-card {
     display: inline-block;
-    margin: 20px;
+    margin: 10px 20px;
     text-align: center;
   }
-  
+
   .bio-card img {
-    width: 150px;
-    height: 150px;
+    width: 140px;
+    height: 140px;
     border-radius: 50%;
     object-fit: cover;
-    margin-bottom: 10px;
+    margin-bottom: 6px;
+  }
+
+  .bio-card p {
+    margin: 4px 0;
+  }
+
+  .bio-role {
+    font-weight: bold;
   }
   
   .bio-link {
@@ -158,18 +168,29 @@
   
   /* Footer CTA */
   .footer-cta {
+    position: relative;
+    left: 50%;
+    margin: 60px 0 0 -50vw;
+    width: 100vw;
     text-align: center;
     padding: 60px 20px;
-    background-color: #ff4500;
+    background: linear-gradient(90deg, #ff4500, #e00000);
     color: white;
-    border-radius: 10px;
+    border-radius: 4px;
   }
-  
+
   .footer-cta h2 {
     font-size: 2rem;
     margin-bottom: 20px;
   }
-  
+
+  .footer-buttons {
+    display: flex;
+    justify-content: center;
+    gap: 15px;
+    flex-wrap: wrap;
+  }
+
   .footer-cta button {
     padding: 14px 28px;
     font-size: 1rem;
@@ -177,13 +198,24 @@
     background: white;
     color: #ff4500;
     font-weight: bold;
-    border-radius: 6px;
+    border-radius: 4px;
     cursor: pointer;
     transition: background 0.3s ease;
   }
-  
+
   .footer-cta button:hover {
     background: #f0f0f0;
+  }
+
+  .footer-cta .ghost {
+    background: transparent;
+    color: white;
+    border: 2px solid white;
+  }
+
+  .trust-line {
+    margin-top: 15px;
+    font-size: 0.85rem;
   }
   
   @media (max-width: 768px) {


### PR DESCRIPTION
## Summary
- Replace fitness trust section with clickable web development feature pills
- Update team cards and about page for developer-focused roles
- Restyle CTA band with gradient, secondary action, and trust line
- Add placeholder Services and Pricing pages and routes

## Testing
- `npm test` (fails: Error: no test specified)
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689c4024ecb88331a5eb067fc5b9ddc3