### PR TITLE
Refine color palette with modern accents

### DIFF
--- a/client/src/components/Navbar.css
+++ b/client/src/components/Navbar.css
@@ -1,5 +1,5 @@
 .navbar {
-    background: #1f1f1f;
+    background: var(--dark-base-color);
     padding: 1rem 2rem;
     box-shadow: 0 2px 6px rgba(0, 0, 0, 0.2);
     position: sticky;
@@ -22,14 +22,14 @@
   .logo {
     font-size: 1.6rem;
     font-weight: 700;
-    color: #ff4500;
+    color: var(--primary-color);
   }
   
 .hamburger {
     font-size: 2rem;
     background: none;
     border: none;
-    color: #ff4500;
+    color: var(--primary-color);
     cursor: pointer;
     display: none;
   }
@@ -64,12 +64,12 @@
   }
   
 .nav-links li a:hover {
-    color: #ff4500;
+    color: var(--primary-color);
   }
 
 .nav-links li a.active {
-    color: #ff4500;
-    border-bottom: 2px solid #ff4500;
+    color: var(--primary-color);
+    border-bottom: 2px solid var(--primary-color);
     font-weight: 700;
   }
 
@@ -86,7 +86,7 @@
     .nav-links {
       display: none;
       flex-direction: column;
-      background: #1f1f1f;
+      background: var(--dark-base-color);
       position: absolute;
       top: 100%;
       left: 0;

--- a/client/src/index.css
+++ b/client/src/index.css
@@ -1,9 +1,14 @@
 @import url('https://fonts.googleapis.com/css2?family=Inter:wght@400;600;700&display=swap');
 
 :root {
-  --primary-color: #ff4500;
-  --text-color: #333;
-  --background-color: #ffffff;
+  --primary-color: #FF6B35;
+  --primary-hover: #FF8C42;
+  --background-color: #F5F6FA;
+  --card-bg-color: #FFFFFF;
+  --section-divider-bg: #ECEEF3;
+  --heading-color: #111827;
+  --text-color: #374151;
+  --dark-base-color: #1E1E2F;
   --font-family: 'Inter', system-ui, sans-serif;
 }
 
@@ -36,7 +41,7 @@ body {
 /* Typography */
 h1, h2, h3 {
   font-weight: 700;
-  color: var(--text-color);
+  color: var(--heading-color);
 }
 
 h1 {
@@ -76,7 +81,7 @@ button,
 
 button:hover,
 .btn-primary:hover {
-  background-color: #d43d00;
+  background-color: var(--primary-hover);
 }
 
 /* Forms */
@@ -91,8 +96,8 @@ input, select, textarea {
 
 /* Navbar */
 .navbar {
-  background: white;
-  border-bottom: 1px solid #eee;
+  background: var(--dark-base-color);
+  border-bottom: 1px solid var(--section-divider-bg);
   position: sticky;
   top: 0;
   z-index: 1000;
@@ -132,7 +137,7 @@ input, select, textarea {
 }
 
 .nav-links li a {
-  color: var(--text-color);
+  color: #fff;
   text-decoration: none;
   font-weight: 600;
   transition: color 0.2s ease;
@@ -150,7 +155,7 @@ input, select, textarea {
   .nav-links {
     display: none;
     flex-direction: column;
-    background: white;
+    background: var(--dark-base-color);
     position: absolute;
     top: 100%;
     left: 0;

--- a/client/src/styles/about.css
+++ b/client/src/styles/about.css
@@ -3,7 +3,8 @@
     margin: 0 auto;
     padding: 60px 20px;
     font-family: Arial, sans-serif;
-    color: #333;
+    color: var(--text-color);
+    background: var(--background-color);
   }
   
   .about-title {

--- a/client/src/styles/home.css
+++ b/client/src/styles/home.css
@@ -1,8 +1,8 @@
 /* General layout */
 .home-container {
     font-family: Arial, sans-serif;
-    color: #222;
-    background: #fff;
+    color: var(--text-color);
+    background: var(--background-color);
     padding: 40px 20px;
     max-width: 1200px;
     margin: 0 auto;
@@ -64,7 +64,7 @@
     border: none;
     cursor: pointer;
     margin-right: 15px;
-    background-color: #ff4500;
+    background-color: var(--primary-color);
     color: white;
     border-radius: 5px;
     transition: background 0.3s ease, transform 0.2s ease;
@@ -72,12 +72,12 @@
   
   .hero-buttons .outline {
     background-color: transparent;
-    color: #ff4500;
-    border: 2px solid #ff4500;
+    color: var(--primary-color);
+    border: 2px solid var(--primary-color);
   }
   
   .hero-buttons button:hover {
-    background-color: #e03e00;
+    background-color: var(--primary-hover);
     transform: translateY(-2px);
   }
   
@@ -96,7 +96,7 @@
     min-width: 200px;
     text-align: center;
     padding: 20px;
-    background: #f7f7f7;
+    background: var(--card-bg-color);
     border-radius: 8px;
     font-weight: bold;
     color: inherit;
@@ -136,17 +136,17 @@
     margin-top: 20px;
     font-weight: bold;
     text-decoration: none;
-    color: #ff4500;
+    color: var(--primary-color);
   }
   
   /* Testimonials */
   .testimonials {
-    background: #fefefe;
+    background: var(--section-divider-bg);
     padding: 40px;
     text-align: center;
     margin-bottom: 60px;
-    border-top: 2px solid #eee;
-    border-bottom: 2px solid #eee;
+    border-top: 2px solid var(--section-divider-bg);
+    border-bottom: 2px solid var(--section-divider-bg);
   }
   
   .testimonials h2 {
@@ -174,7 +174,7 @@
     width: 100vw;
     text-align: center;
     padding: 60px 20px;
-    background: linear-gradient(90deg, #ff4500, #e00000);
+    background: linear-gradient(135deg, var(--primary-color), var(--primary-hover));
     color: white;
     border-radius: 4px;
   }
@@ -196,7 +196,7 @@
     font-size: 1rem;
     border: none;
     background: white;
-    color: #ff4500;
+    color: var(--primary-color);
     font-weight: bold;
     border-radius: 4px;
     cursor: pointer;


### PR DESCRIPTION
## Summary
- centralize new color variables for primary, background, text, and dark base
- update navigation, buttons, and sections to use refreshed palette
- apply gradient CTA and white card backgrounds on home page

## Testing
- `npm test` *(fails: Error: no test specified)*
- `cd client && npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689c429335dc83318a1518f4d8017b76