### PR TITLE
Tone down orange accents

### DIFF
--- a/client/src/styles/home.css
+++ b/client/src/styles/home.css
@@ -69,16 +69,22 @@
     border-radius: 5px;
     transition: background 0.3s ease, transform 0.2s ease;
   }
-  
+
   .hero-buttons .outline {
     background-color: transparent;
-    color: var(--primary-color);
-    border: 2px solid var(--primary-color);
+    color: var(--dark-base-color);
+    border: 2px solid var(--section-divider-bg);
   }
-  
+
   .hero-buttons button:hover {
     background-color: var(--primary-hover);
     transform: translateY(-2px);
+  }
+
+  .hero-buttons .outline:hover {
+    background-color: transparent;
+    color: var(--primary-color);
+    border-color: var(--primary-color);
   }
   
   
@@ -174,7 +180,7 @@
     width: 100vw;
     text-align: center;
     padding: 60px 20px;
-    background: linear-gradient(135deg, var(--primary-color), var(--primary-hover));
+    background: var(--dark-base-color);
     color: white;
     border-radius: 4px;
   }
@@ -195,8 +201,8 @@
     padding: 14px 28px;
     font-size: 1rem;
     border: none;
-    background: white;
-    color: var(--primary-color);
+    background: var(--primary-color);
+    color: white;
     font-weight: bold;
     border-radius: 4px;
     cursor: pointer;
@@ -204,13 +210,18 @@
   }
 
   .footer-cta button:hover {
-    background: #f0f0f0;
+    background: var(--primary-hover);
   }
 
   .footer-cta .ghost {
     background: transparent;
     color: white;
     border: 2px solid white;
+  }
+
+  .footer-cta .ghost:hover {
+    background: white;
+    color: var(--dark-base-color);
   }
 
   .trust-line {


### PR DESCRIPTION
## Summary
- Soften secondary call-to-action button by switching its default outline to muted colors and only using orange on hover.
- Restyle the "Ready to build?" CTA band with a navy background, orange primary button, and white outline variant.

## Testing
- `npm test` (fails: no test specified)
- `cd client && npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_689d86a44a6c83319d0da868bcd87413